### PR TITLE
Transaction waiting/printing, batch operations

### DIFF
--- a/cli/args.go
+++ b/cli/args.go
@@ -32,11 +32,9 @@ func ChainArgs(funcs ...func(cmd *cobra.Command, args []string) error) func(*cob
 func GetArgAddress(index int, args []string) (common.Address, error) {
 	var addr common.Address
 	if len(args) < index+1 {
-		if !common.IsHexAddress(viper.GetString("keystoreAddress")) {
-			return addr, errors.New("missing one of <address> or <keystoreAddress> args")
-		}
-		return common.HexToAddress(viper.GetString("keystoreAddress")), nil
+		return addr, fmt.Errorf("requires address arg")
 	}
+
 	if !common.IsHexAddress(args[index]) {
 		return addr, errors.New("invalid address for <address> arg")
 	}
@@ -177,7 +175,7 @@ func HexArgFunc(key string, index int, length int) func(*cobra.Command, []string
 
 		b, err := hexutil.Decode(args[index])
 		l := hex.DecodedLen(len(b))
-		if err == nil && l != length/2 {
+		if err == nil && l != length {
 			err = fmt.Errorf("hex arg <%s> data size %d is different than the required length %d", key, l, length)
 		}
 		return err

--- a/cli/connect.go
+++ b/cli/connect.go
@@ -31,7 +31,7 @@ func getAddress(cmd *cobra.Command) (common.Address, string, bool, error) {
 	}
 
 	// Get the address and optional password, for the alias
-	return addressForKeystoreAlias(f)
+	return AddressForKeystoreAlias(f)
 }
 
 // Connect creates a connection to the node

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -29,8 +29,8 @@ func FlagOrConfigAddress(cmd *cobra.Command, flag, configKey string) (common.Add
 	return common.HexToAddress(s), err
 }
 
-// addressForKeystoreAlias returns the address in the config 'keystoreAddressAliases' secion of the given alias
-func addressForKeystoreAlias(alias string) (common.Address, string, bool, error) {
+// AddressForKeystoreAlias returns the address in the config 'keystoreAddressAliases' secion of the given alias
+func AddressForKeystoreAlias(alias string) (common.Address, string, bool, error) {
 	var addr common.Address
 	var passphrase string
 	var hasPassphrase bool

--- a/cli/transaction.go
+++ b/cli/transaction.go
@@ -2,13 +2,19 @@ package cli
 
 import (
 	"context"
+	//"encoding/json"
 	"errors"
+	"fmt"
+	"io"
 	"math/big"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/spf13/cobra"
 
 	"github.com/tzero-dev/go-t0ken/units"
@@ -16,13 +22,109 @@ import (
 
 var waitDuration = time.Duration(1 * time.Second)
 
-func waitOnTransaction(cmd *cobra.Command, tx *types.Transaction, timeout int) error {
+// PrintBlock prints the block info.
+func PrintBlock(w io.Writer, latest *types.Header, block *types.Block) error {
+	// Header info
+	header := block.Header()
+	confirmations := new(big.Int).Sub(latest.Number, header.Number).Uint64()
+	used := header.GasUsed
+	limit := header.GasLimit
+	percent := float64(0)
+	if limit > 0 {
+		percent = (float64(used) / float64(limit)) * 100
+	}
+	rlpData := []string{}
+	rlp.DecodeBytes(header.Extra, &rlpData)
+
+	// Print the block information
+	_, err := fmt.Fprintf(w, `        Block: %s (%s)
+Confirmations: %d
+    Gas Limit: %d
+     Gas Used: %d (%.2f%%)
+   Difficulty: %s
+         Size: %s
+      Receipt: %s
+       Parent: %s
+    Sha3Uncle: %s
+   Extra Data: %s
+`,
+		header.Number, header.Hash().String(),
+		confirmations,
+		limit,
+		used, percent,
+		header.Difficulty,
+		header.Size().String(),
+		header.ReceiptHash.String(),
+		header.ParentHash.String(),
+		header.UncleHash.String(),
+		strings.Join(rlpData, " "))
+	return err
+}
+
+// PrintTransaction prints the transaction info.
+func PrintTransaction(w io.Writer, tx *types.Transaction) error {
+	value := units.ConvertInt(tx.Value(), units.Wei, units.Ether)
+	cost := units.ConvertInt(tx.Cost(), units.Wei, units.Ether)
+	price := units.ConvertInt(tx.GasPrice(), units.Wei, units.Gwei)
+	_, err := fmt.Fprintf(w, `  Transaction: %s
+        Value: %s Ether
+      Tx Cost: %s Ether
+    Gas Price: %s Gwei
+        Nonce: %d
+`,
+		tx.Hash().String(),
+		value.Text('f', 9),
+		cost.Text('f', 9),
+		price.Text('f', 4),
+		tx.Nonce())
+
+	return err
+}
+
+type transactionReceiptBlock struct {
+	BlockHash   common.Hash    `json:"blockHash"`
+	BlockNumber hexutil.Uint64 `json:"blockNumber"`
+}
+
+func receiptBlock(hash common.Hash) (*types.Block, error) {
+	//// Ensure the transaction is successful
+	//tr, err := Conn.TransactionReceipt(context.Background(), hash)
+	//if err != nil {
+	//	return nil, err
+	//} else if tr.Status != 1 {
+	//	return nil, fmt.Errorf("transaction failed with status:", tr.Status)
+	//}
+	//
+	//// Only attempting to get logs so we can natively get to the block number, since we can't with current Geth 1.8.
+	//// The issue is that not every transaction includes logs, so this is unreliable.
+	//// We can use a filter query, but without knowing the block range this could be intensive.
+	//if len(tr.Logs) == 0 {
+	//	return nil, errors.New("Receipt contains no logs to get block, awaiting on go-ethereum PR-17662 to remedy this")
+	//}
+	//h := tr.Logs[0].BlockHash
+	//return Conn.BlockByHash(context.Background(), h)
+
+	// https://github.com/ethereum/go-ethereum/pull/17662#pullrequestreview-206299201
+	// We should be able to use the above PR, which will hopefully be included in the 1.9.x release to get the block number.
+	// But for now, issuing a raw query and parsing the bits we need will suffice.
+	var r *transactionReceiptBlock
+	err := Conn.RawCall(&r, "eth_getTransactionReceipt", hash)
+	if err != nil {
+		return nil, err
+	}
+	return Conn.BlockByHash(context.Background(), r.BlockHash)
+}
+
+func WaitOnTransaction(cmd *cobra.Command, tx common.Hash, timeout int) error {
+	// Wait for the transaction to be mined
 	elapsed := 0
 	for {
-		_, pending, err := Conn.TransactionByHash(context.Background(), tx.Hash())
+		_, pending, err := Conn.TransactionByHash(context.Background(), tx)
 		if err != nil {
 			return err
-		} else if !pending || timeout > 0 && elapsed-timeout > 0 {
+		} else if timeout > 0 && elapsed-timeout > 0 {
+			return errors.New("Exceederd timeout")
+		} else if !pending {
 			break
 		}
 
@@ -30,14 +132,100 @@ func waitOnTransaction(cmd *cobra.Command, tx *types.Transaction, timeout int) e
 		elapsed += 1
 		cmd.Print(".")
 	}
-	if timeout > 0 && elapsed-timeout > 0 {
-		cmd.Println("\nExceeded timeout")
-	} else {
-		cmd.Println("\nTransaction accepted")
+
+	// Ensure the transaction is successful
+	tr, err := Conn.TransactionReceipt(context.Background(), tx)
+	if err != nil {
+		return err
+	} else if tr.Status != 1 {
+		return fmt.Errorf("transaction failed with status:", tr.Status)
 	}
+
+	// Get latest block
+	latest, err := Conn.HeaderByNumber(context.Background(), nil)
+	if err != nil {
+		return err
+	}
+
+	// Output block info from receipt
+	block, err := receiptBlock(tx)
+	if err == nil {
+		err = PrintBlock(cmd.OutOrStdout(), latest, block)
+	}
+	return err
+}
+
+func WaitOnTransactions(cmd *cobra.Command, transactions []common.Hash, timeout int) error {
+	// Wait for all transaction confirmations
+	for _, tx := range transactions {
+		elapsed := 0
+		_, pending, err := Conn.TransactionByHash(context.Background(), tx)
+		if err != nil {
+			cmd.Printf("failed to retrieve transaction '%s', %s\n", tx.String(), err)
+			break
+		} else if timeout > 0 && elapsed-timeout > 0 {
+			return errors.New("exceederd timeout")
+		} else if !pending {
+			if elapsed > 0 {
+				cmd.Printf("Confirmed transaction: %s\n", tx.String())
+			}
+			break
+		}
+		<-time.After(waitDuration)
+		elapsed += 1
+		cmd.Print(".")
+	}
+
+	// Get the blocks the transactions are included in
+	var blocks []*types.Block
+	blockTx := make(map[uint64][]string)
+	for _, tx := range transactions {
+		// Ensure the transaction is successful
+		tr, err := Conn.TransactionReceipt(context.Background(), tx)
+		if err != nil {
+			cmd.Printf("failed retrieving receipt for '%s', %s\n", tx.String(), err)
+			continue
+		} else if tr.Status != 1 {
+			cmd.Printf("transaction '%s' failed with status: %d\n", tx.String(), tr.Status)
+			continue
+		}
+		block, err := receiptBlock(tx)
+		if err != nil {
+			cmd.Printf("failed to get block for transaction '%s', %s\n", tx.String(), err)
+			continue
+		}
+		n := block.NumberU64()
+		blocks = append(blocks, block)
+		blockTx[n] = append(blockTx[n], tx.String())
+	}
+
+	// Get latest block
+	latest, err := Conn.HeaderByNumber(context.Background(), nil)
+	if err != nil {
+		return err
+	}
+
+	// Print block(s)
+	for _, block := range blocks {
+		s, ok := blockTx[block.NumberU64()]
+		if !ok {
+			continue
+		}
+
+		cmd.Println("--------------------------------------------------------------------------------")
+		t := strings.Join(s, "\n               ")
+		cmd.Printf("Block %s\n Transactions: %s\n               ...\n", block.Number().String(), t)
+		err := PrintBlock(cmd.OutOrStdout(), latest, block)
+		if err != nil {
+			return err
+		}
+		delete(blockTx, block.NumberU64())
+	}
+
 	return nil
 }
 
+// ReplayTransaction attempts to replay an existing, pending transaction.
 func ReplayTransaction(cmd *cobra.Command, h common.Hash, gasPrice *big.Int) error {
 	tx, pending, err := Conn.TransactionByHash(context.Background(), h)
 	if err != nil {
@@ -54,7 +242,7 @@ func ReplayTransaction(cmd *cobra.Command, h common.Hash, gasPrice *big.Int) err
 func PrintTransactionFn(cmd *cobra.Command) func(*types.Transaction, error) {
 	return func(tx *types.Transaction, err error) {
 		CheckErr(cmd, err)
-		PrintTransaction(cmd, tx)
+		PrintTransaction(cmd.OutOrStdout(), tx)
 		f := cmd.Flag("wait")
 		if f == nil {
 			return
@@ -63,37 +251,7 @@ func PrintTransactionFn(cmd *cobra.Command) func(*types.Transaction, error) {
 		if err != nil || seconds < 0 {
 			return
 		}
-		err = waitOnTransaction(cmd, tx, seconds)
+		err = WaitOnTransaction(cmd, tx.Hash(), seconds)
 		CheckErr(cmd, err)
 	}
-}
-
-// PrintTransaction prints the transaction info.
-func PrintTransaction(cmd *cobra.Command, tx *types.Transaction) {
-	cost := units.ConvertInt(tx.Cost(), units.Wei, units.Ether)
-	price := units.ConvertInt(tx.GasPrice(), units.Wei, units.Gwei)
-	used := tx.Gas()
-	limit := Conn.Opts.GasLimit
-	limitStr := string(limit)
-	percent := uint64(0)
-	if limit > 0 {
-		percent = used / limit
-	} else {
-		limitStr = "~"
-	}
-
-	cmd.Printf(`
-Transaction: %s
-       Cost: %s Ether
-  Gas Limit: %s
-   Gas Used: %d (%d%%)
-  Gas Price: %s Gwei
-      Nonce: %d
-`,
-		tx.Hash().String(),
-		cost.Text('f', 9),
-		limitStr,
-		used, percent,
-		price.Text('f', 4),
-		tx.Nonce())
 }

--- a/cmd/t0ken/main.go
+++ b/cmd/t0ken/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	t0ken "github.com/tzero-dev/go-t0ken"
 	"github.com/tzero-dev/go-t0ken/commands/broker"
 	"github.com/tzero-dev/go-t0ken/commands/compliance"
 	"github.com/tzero-dev/go-t0ken/commands/custodian"
@@ -16,9 +17,8 @@ import (
 	"github.com/tzero-dev/go-t0ken/commands/nonce"
 	"github.com/tzero-dev/go-t0ken/commands/storage"
 	"github.com/tzero-dev/go-t0ken/commands/token"
+	"github.com/tzero-dev/go-t0ken/commands/transaction"
 )
-
-const VERSION = "0.0.3"
 
 var configFile string
 
@@ -31,7 +31,7 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Displays the t0ken version",
 	Run: func(cmd *cobra.Command, args []string) {
-		cmd.Println(VERSION)
+		cmd.Println(t0ken.VERSION)
 	},
 }
 
@@ -107,6 +107,12 @@ func main() {
 	ether.Command.AddCommand(ether.SendCommand)
 	ether.Command.AddCommand(ether.BalanceCommand)
 	rootCmd.AddCommand(ether.Command)
+
+	// Transaction
+	transaction.Command.AddCommand(transaction.ReplayCommand)
+	transaction.Command.AddCommand(transaction.CancelCommand)
+	transaction.Command.AddCommand(transaction.NextAddressCommand)
+	rootCmd.AddCommand(transaction.Command)
 
 	// Token
 	token.Command.AddCommand(token.DeployCommand)

--- a/cmd/t0ken/main.go
+++ b/cmd/t0ken/main.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	t0ken "github.com/tzero-dev/go-t0ken"
+	"github.com/tzero-dev/go-t0ken"
 	"github.com/tzero-dev/go-t0ken/commands/broker"
 	"github.com/tzero-dev/go-t0ken/commands/compliance"
 	"github.com/tzero-dev/go-t0ken/commands/custodian"
@@ -112,10 +112,12 @@ func main() {
 	transaction.Command.AddCommand(transaction.ReplayCommand)
 	transaction.Command.AddCommand(transaction.CancelCommand)
 	transaction.Command.AddCommand(transaction.NextAddressCommand)
+	transaction.Command.AddCommand(transaction.WaitCommand)
 	rootCmd.AddCommand(transaction.Command)
 
 	// Token
 	token.Command.AddCommand(token.DeployCommand)
+	token.Command.AddCommand(token.AuditCommand)
 	token.Command.AddCommand(token.GetterCommands...)
 	token.Command.AddCommand(token.SetterCommands...)
 	rootCmd.AddCommand(token.Command)
@@ -128,6 +130,7 @@ func main() {
 
 	// Registry, Storage
 	storage.Command.AddCommand(storage.DeployCommand)
+	storage.Command.AddCommand(storage.AuditCommand)
 	storage.Command.AddCommand(storage.GetterCommands...)
 	storage.Command.AddCommand(storage.SetterCommands...)
 	rootCmd.AddCommand(storage.Command)

--- a/cmd/t0ken/main.go
+++ b/cmd/t0ken/main.go
@@ -49,7 +49,7 @@ To configure your bash shell to load completions for each session add to your ba
 . <(t0ken completion)
 
 # --- zsh ---
-t0ken completion > /fpath/location/_t0ken
+t0ken completion zsh > /fpath/location/_t0ken
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		genFn := rootCmd.GenBashCompletion

--- a/cmd/t0kenbatch/main.go
+++ b/cmd/t0kenbatch/main.go
@@ -1,0 +1,368 @@
+package main
+
+import (
+	"encoding/csv"
+	"fmt"
+	"io"
+	"math/big"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/tzero-dev/go-t0ken"
+	"github.com/tzero-dev/go-t0ken/cli"
+	"github.com/tzero-dev/go-t0ken/commands"
+	"github.com/tzero-dev/go-t0ken/contracts/registry"
+	"github.com/tzero-dev/go-t0ken/contracts/token/erc20"
+)
+
+var one = new(big.Int).SetInt64(1)
+
+var configFile string
+
+var rootCmd = &cobra.Command{
+	Use:   "t0kenbatch [OPTIONS] COMMAND [ARG...]",
+	Short: "Batch functions for use with tZERO Ethereum smart contracts",
+}
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Displays the t0kenbatch version",
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Println(t0ken.VERSION)
+	},
+}
+
+var completionCmd = &cobra.Command{
+	Use:   "completion [shell] (default 'bash' or 'zsh')",
+	Short: "Generates shell completion scripts",
+	Long: `To load completion run
+
+# --- bash ---
+. <(t0kenbatch completion)
+
+To configure your bash shell to load completions for each session add to your bashrc
+
+# ~/.bashrc or ~/.profile
+. <(t0kenbatch completion)
+
+# --- zsh ---
+t0kenbatch completion zsh > /fpath/location/_t0kenbatch
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		genFn := rootCmd.GenBashCompletion
+		if len(args) > 0 {
+			switch args[0] {
+			case "bash":
+			case "zsh":
+				genFn = rootCmd.GenZshCompletion
+			default:
+				cmd.Println("Invalid shell name, expecting one of 'bash', 'zsh'")
+				os.Exit(1)
+			}
+		}
+		genFn(os.Stdout)
+	},
+}
+
+type header int
+
+const (
+	ADDRESS header = iota
+	HASH
+	COUNTRY
+	ACCREDITATION
+	TOKENS
+)
+
+type headers [5]int
+
+type InvestorMsg struct {
+	Investor Investor
+	Error    error
+}
+type Investor struct {
+	Address       common.Address
+	Hash          [32]byte
+	Country       [2]byte
+	Accreditation *big.Int
+	Tokens        *big.Int
+}
+
+func (i Investor) String() string {
+	return fmt.Sprintf("%s, Hash: %#x, Country: %s, Accreditation: %s, Tokens: %s", i.Address.String(), i.Hash[:], string(i.Country[:]), i.Accreditation, i.Tokens.String())
+}
+
+func investorHeaders(s []string) (headers, error) {
+	var h headers
+	c := 0
+	for i := 0; i < len(s); i++ {
+		switch strings.ToUpper(s[i]) {
+		case "ADDRESS":
+			h[ADDRESS] = i
+			c++
+		case "HASH":
+			h[HASH] = i
+			c++
+		case "COUNTRY":
+			h[COUNTRY] = i
+			c++
+		case "ACCREDITATION":
+			h[ACCREDITATION] = i
+			c++
+		case "TOKENS":
+			h[TOKENS] = i
+			c++
+		}
+	}
+	var err error
+	return h, err
+}
+
+func newInvestor(row []string, h headers, isIssuance bool) (Investor, error) {
+	var i Investor
+
+	if !common.IsHexAddress(row[h[ADDRESS]]) {
+		return i, fmt.Errorf("invalid address: '%s'", row[h[ADDRESS]])
+	}
+
+	hash, err := hexutil.Decode(row[h[HASH]])
+	if err != nil {
+		return i, fmt.Errorf("invalid hash: '%s', %s", row[h[HASH]], err)
+	}
+
+	c, err := cli.CountryFromArg(row[h[COUNTRY]])
+	if err != nil {
+		return i, fmt.Errorf("invalid country: '%s', %s", row[h[COUNTRY]], err)
+	}
+
+	a, err := cli.DateFromArg(row[h[ACCREDITATION]])
+	if err != nil {
+		return i, fmt.Errorf("invalid accreditation: '%s', %s", row[h[ACCREDITATION]], err)
+	}
+
+	var tokens int
+	if isIssuance {
+		tokens, err = strconv.Atoi(row[h[TOKENS]])
+		if err != nil {
+			return i, fmt.Errorf("invalid tokens: '%s', %s", row[h[TOKENS]], err)
+		}
+	}
+
+	var b [32]byte
+	copy(b[:], hash)
+	return Investor{
+		Address:       common.HexToAddress(row[h[ADDRESS]]),
+		Hash:          b,
+		Country:       c,
+		Accreditation: big.NewInt(a.Unix()),
+		Tokens:        big.NewInt(int64(tokens)),
+	}, nil
+}
+
+func parseInvestorCSV(r io.Reader, isIssuance bool) <-chan InvestorMsg {
+	c := make(chan InvestorMsg)
+	go func(ch chan<- InvestorMsg) {
+		reader := csv.NewReader(r)
+		index := -1
+		var h headers
+		for {
+			index++
+			row, err := reader.Read()
+			switch {
+			case err == io.EOF:
+				close(ch)
+				return
+			case err != nil:
+				ch <- InvestorMsg{Error: err}
+				return
+			case index == 0:
+				h, err = investorHeaders(row)
+				if err != nil {
+					ch <- InvestorMsg{Error: err}
+				}
+				continue
+			}
+
+			i, err := newInvestor(row, h, isIssuance)
+			if err != nil {
+				err = fmt.Errorf("error processing at row: %d, %s", index, err)
+			}
+			ch <- InvestorMsg{Investor: i, Error: err}
+		}
+		close(ch)
+	}(c)
+	return c
+}
+
+func investorTransactorSessionFn(addr common.Address, transactor bind.ContractTransactor) (interface{}, error) {
+	return registry.NewInvestorTransactor(addr, transactor)
+}
+
+var onboardInvestorCommand = &cobra.Command{
+	Use:   "onboardInvestors <file>",
+	Short: "Onboards the investors from the given CSV <file>",
+	Long: `The CSV file must be in the following format:
+---
+address,hash,country,accreditation
+0xf01ff29dcbee147e9ca151a281bfdf136f66a45b,0xa1896382c22b03c562b0241324cfca19505cc5c78eb06751d9cee690e21ed6a1,US,2012-08-24
+---
+
+ - The header column must be present, with all values being required.
+ - The country must be in "ISO 3166-1 alpha-2" format
+ - The accreditation must UTC and be in "YYYY-MM-DD" format`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		// Open file
+		f, err := os.Open(args[0])
+		cli.CheckErr(cmd, err)
+
+		// Connect to node
+		o, transactOpts := commands.ConnectWithTransactorSessionFunc(cmd, args, "investorRegistry", investorTransactorSessionFn)
+		transactor := o.(*registry.InvestorTransactor)
+		transSession := &registry.InvestorTransactorSession{transactor, transactOpts}
+		nonce := cli.Conn.Opts.Nonce
+
+		// Onboard
+		var transactions []common.Hash
+		for msg := range parseInvestorCSV(f, false) {
+			if msg.Error != nil {
+				cmd.Println(msg.Error)
+				break
+			}
+
+			i := msg.Investor
+			tx, err := transSession.Add(i.Address, i.Hash, i.Country, i.Accreditation)
+			if err != nil {
+				cmd.Printf("Failed onboarding '%s', %s\n", i.Address.String(), err)
+				continue
+			}
+
+			nonce.Add(nonce, one)
+			transactions = append(transactions, tx.Hash())
+			cli.PrintTransaction(cmd.OutOrStdout(), tx)
+		}
+
+		// Wait on the transaction
+		if len(transactions) == 1 {
+			err = cli.WaitOnTransaction(cmd, transactions[0], 0)
+		} else {
+			err = cli.WaitOnTransactions(cmd, transactions, 0)
+		}
+		cli.CheckErr(cmd, err)
+	},
+}
+
+func tokenTransactorSessionFn(addr common.Address, transactor bind.ContractTransactor) (interface{}, error) {
+	return erc20.NewT0kenTransactor(addr, transactor)
+}
+
+var issueTokensCommand = &cobra.Command{
+	Use:   "issuance <file>",
+	Short: "Issues tokens to investors from the given CSV <file>",
+	Long: `The CSV file must be in the following format:
+---
+address,tokens
+0xf01ff29dcbee147e9ca151a281bfdf136f66a45b,66
+---
+
+ - The header column must be present, with all values being required.
+`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		// Open file
+		f, err := os.Open(args[0])
+		cli.CheckErr(cmd, err)
+
+		// Connect to node
+		o, transactOpts := commands.ConnectWithTransactorSessionFunc(cmd, args, "t0ken", tokenTransactorSessionFn)
+		transactor := o.(*erc20.T0kenTransactor)
+		transSession := &erc20.T0kenTransactorSession{transactor, transactOpts}
+		nonce := cli.Conn.Opts.Nonce
+
+		// Onboard
+		var transactions []common.Hash
+		for msg := range parseInvestorCSV(f, true) {
+			if msg.Error != nil {
+				cmd.Println(msg.Error)
+				break
+			}
+
+			i := msg.Investor
+			tx, err := transSession.Transfer(i.Address, i.Tokens)
+			if err != nil {
+				cmd.Printf("Failed onboarding '%s', %s\n", i.Address.String(), err)
+				continue
+			}
+
+			nonce.Add(nonce, one)
+			transactions = append(transactions, tx.Hash())
+			cli.PrintTransaction(cmd.OutOrStdout(), tx)
+		}
+
+		// Wait on the transaction
+		if len(transactions) == 1 {
+			err = cli.WaitOnTransaction(cmd, transactions[0], 0)
+		} else {
+			err = cli.WaitOnTransactions(cmd, transactions, 0)
+		}
+		cli.CheckErr(cmd, err)
+	},
+}
+
+func init() {
+	cobra.OnInitialize(initConfig)
+
+	rootCmd.PersistentFlags().StringVar(&configFile, "config", "t0ken.yaml", "config file")
+	rootCmd.PersistentFlags().String("url", "http://localhost:8545", "URL to an Ethereum node")
+	rootCmd.PersistentFlags().String("keystore", ".keystore", "keystore path")
+	rootCmd.PersistentFlags().String("keystoreAddress", "", "address to use within the keystore")
+
+	viper.BindPFlag("url", rootCmd.PersistentFlags().Lookup("url"))
+	viper.BindPFlag("keystore", rootCmd.PersistentFlags().Lookup("keystore"))
+	viper.BindPFlag("keystoreAddress", rootCmd.PersistentFlags().Lookup("keystoreAddress"))
+}
+
+func initConfig() {
+	if configFile != "" {
+		viper.SetConfigFile(configFile)
+	}
+	err := viper.ReadInConfig()
+	if err != nil {
+		fmt.Printf("Failed to read config: %s - %s\n", configFile, err)
+		os.Exit(1)
+	}
+}
+
+func main() {
+	rootCmd.AddCommand(versionCmd)
+	rootCmd.AddCommand(completionCmd)
+
+	onboardInvestorCommand.Flags().String("address", "", `address of the BrokerDealer registry contract (default "[investorRegistry] value from config")`)
+	onboardInvestorCommand.Flags().Int("wait", -1, "waits the provided number of seconds for the transaction to be mined ('0' waits indefinitely)")
+	issueTokensCommand.Flags().String("address", "", `address of the BrokerDealer registry contract (default "[investorRegistry] value from config")`)
+	issueTokensCommand.Flags().Int("wait", -1, "waits the provided number of seconds for the transaction to be mined ('0' waits indefinitely)")
+
+	rootCmd.AddCommand(onboardInvestorCommand)
+	rootCmd.AddCommand(issueTokensCommand)
+
+	err := rootCmd.Execute()
+	if err != nil {
+		os.Exit(1)
+	}
+}
+
+/*
+✱ t0ken storage deploy
+✱ t0ken investor deploy
+✱ t0ken storage grantPermission 4 0x0000000000000000000000000000000000000000
+✱ t0ken investor setStorage 0x0000000000000000000000000000000000000000
+✱ t0ken storage addAccount 0xa42c038b9f7dfabf95298024fbaae9e54e4f0abf 3 false 0xa42c038b9f7dfabf95298024fbaae9e54e4f0abf
+✱ t0kenbatch onboardInvestors investors.csv
+*/

--- a/commands/administrable/administrable.go
+++ b/commands/administrable/administrable.go
@@ -67,7 +67,7 @@ func NewSetterCommands(contractConfigKey string) []*cobra.Command {
 			PreRun: connect,
 			Run: func(cmd *cobra.Command, args []string) {
 				addr := common.HexToAddress(args[0])
-				cli.PrintTransFn(cmd)(session.AddAdmin(addr))
+				cli.PrintTransactionFn(cmd)(session.AddAdmin(addr))
 			},
 		},
 		&cobra.Command{
@@ -77,7 +77,7 @@ func NewSetterCommands(contractConfigKey string) []*cobra.Command {
 			PreRun: connect,
 			Run: func(cmd *cobra.Command, args []string) {
 				addr := common.HexToAddress(args[0])
-				cli.PrintTransFn(cmd)(session.RemoveAdmin(addr))
+				cli.PrintTransactionFn(cmd)(session.RemoveAdmin(addr))
 			},
 		},
 	}

--- a/commands/broker/broker.go
+++ b/commands/broker/broker.go
@@ -23,13 +23,13 @@ var (
 		Short:   "Deploys a new broker-dealer registry contract",
 		Example: "t0ken broker deploy --keystoreAddress owner",
 		Args:    cobra.NoArgs,
-		PreRun:  connectTransactor,
+		PreRun:  commands.ConnectWithKeyStore,
 		Run: func(cmd *cobra.Command, args []string) {
 			// Deploy the broker-dealer using for the symbol/name/decimals
 			addr, tx, _, err := registry.DeployBrokerDealer(cli.Conn.Opts, cli.Conn.Client)
 			cli.CheckErr(cmd, err)
 			cmd.Println("   Contract:", addr.String())
-			cli.PrintTransFn(cmd)(tx, nil)
+			cli.PrintTransactionFn(cmd)(tx, nil)
 		},
 	}
 

--- a/commands/broker/setters.go
+++ b/commands/broker/setters.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/tzero-dev/go-t0ken/cli"
 	"github.com/tzero-dev/go-t0ken/commands/destroyable"
+	"github.com/tzero-dev/go-t0ken/commands/gas"
 	"github.com/tzero-dev/go-t0ken/commands/lockable"
+	"github.com/tzero-dev/go-t0ken/commands/nonce"
 	"github.com/tzero-dev/go-t0ken/commands/ownable"
 )
 
@@ -19,7 +21,7 @@ var SetterCommands = []*cobra.Command{
 		PreRun:  connectTransactor,
 		Run: func(cmd *cobra.Command, args []string) {
 			broker := common.HexToAddress(args[0])
-			cli.PrintTransFn(cmd)(transSession.Add(broker))
+			cli.PrintTransactionFn(cmd)(transSession.Add(broker))
 		},
 	},
 	&cobra.Command{
@@ -31,7 +33,7 @@ var SetterCommands = []*cobra.Command{
 		Run: func(cmd *cobra.Command, args []string) {
 			broker := common.HexToAddress(args[0])
 			custodialAccount := common.HexToAddress(args[1])
-			cli.PrintTransFn(cmd)(transSession.AddAccount(broker, custodialAccount))
+			cli.PrintTransactionFn(cmd)(transSession.AddAccount(broker, custodialAccount))
 		},
 	},
 	&cobra.Command{
@@ -42,7 +44,7 @@ var SetterCommands = []*cobra.Command{
 		PreRun:  connectTransactor,
 		Run: func(cmd *cobra.Command, args []string) {
 			addr := common.HexToAddress(args[0])
-			cli.PrintTransFn(cmd)(transSession.Remove(addr))
+			cli.PrintTransactionFn(cmd)(transSession.Remove(addr))
 		},
 	},
 	&cobra.Command{
@@ -53,7 +55,7 @@ var SetterCommands = []*cobra.Command{
 		PreRun:  connectTransactor,
 		Run: func(cmd *cobra.Command, args []string) {
 			custodialAccount := common.HexToAddress(args[0])
-			cli.PrintTransFn(cmd)(transSession.RemoveAccount(custodialAccount))
+			cli.PrintTransactionFn(cmd)(transSession.RemoveAccount(custodialAccount))
 		},
 	},
 	&cobra.Command{
@@ -64,7 +66,7 @@ var SetterCommands = []*cobra.Command{
 		PreRun:  connectTransactor,
 		Run: func(cmd *cobra.Command, args []string) {
 			addr := common.HexToAddress(args[0])
-			cli.PrintTransFn(cmd)(transSession.SetStorage(addr))
+			cli.PrintTransactionFn(cmd)(transSession.SetStorage(addr))
 		},
 	},
 }
@@ -76,6 +78,10 @@ func init() {
 	SetterCommands = append(SetterCommands, ownable.NewSetterCommands(contractKey)...)
 
 	for _, cmd := range SetterCommands {
+		// Allow 'gasPrice' and 'nonce' flags
+		gas.Flag(cmd)
+		nonce.Flag(cmd)
+
 		// Allow providing contract 'address' flag
 		cmd.Flags().String("address", "", `address of the BrokerDealer registry contract (default "[`+contractKey+`] value from config")`)
 		cmd.Flags().Int("wait", -1, "waits the provided number of seconds for the transaction to be mined ('0' waits indefinitely)")

--- a/commands/compliance/tokenCompliance.go
+++ b/commands/compliance/tokenCompliance.go
@@ -23,14 +23,14 @@ var (
 		Short:   "Deploys a new t0ken-compliance contract",
 		Example: "t0ken compliance deploy --keystoreAddress owner",
 		Args:    cobra.NoArgs,
-		PreRun:  cli.ConnectWithKeyStore,
+		PreRun:  commands.ConnectWithKeyStore,
 		// TODO: refactor these deploy funcs into something...
 		Run: func(cmd *cobra.Command, args []string) {
 			// Deploy the token-compliance using for the symbol/name/decimals
 			addr, tx, _, err := compliance.DeployT0kenCompliance(cli.Conn.Opts, cli.Conn.Client)
 			cli.CheckErr(cmd, err)
 			cmd.Println("   Contract:", addr.String())
-			cli.PrintTransFn(cmd)(tx, nil)
+			cli.PrintTransactionFn(cmd)(tx, nil)
 		},
 	}
 

--- a/commands/connect.go
+++ b/commands/connect.go
@@ -13,6 +13,21 @@ import (
 type CallerSessionFunc func(common.Address, bind.ContractCaller) (interface{}, error)
 type TransactorSessionFunc func(common.Address, bind.ContractTransactor) (interface{}, error)
 
+// ConnectWithKeyStore establishes a connection with gasPrice and nonce values set.
+func ConnectWithKeyStore(cmd *cobra.Command, args []string) {
+	cli.ConnectWithKeyStore(cmd, args)
+
+	// Set gas price
+	gasPrice, err := gas.GetPrice(cmd, args)
+	cli.CheckErr(cmd, err)
+	cli.Conn.SetGasPrice(gasPrice)
+
+	// Set nonce
+	n, err := nonce.Get()
+	cli.CheckErr(cmd, err)
+	cli.Conn.SetNonce(n)
+}
+
 // ConnectWithCallerSession establishes a T0kenCompliance caller session.
 func ConnectWithCallerSessionFunc(cmd *cobra.Command, args []string, contractConfigKey string, fn CallerSessionFunc) (interface{}, bind.CallOpts) {
 	var caller interface{}
@@ -27,19 +42,8 @@ func ConnectWithCallerSessionFunc(cmd *cobra.Command, args []string, contractCon
 
 // ConnectWithTransactorSession establishes a T0kenCompliance transactor session.
 func ConnectWithTransactorSessionFunc(cmd *cobra.Command, args []string, contractConfigKey string, fn TransactorSessionFunc) (interface{}, bind.TransactOpts) {
-	cli.ConnectWithKeyStore(cmd, args)
-
-	// Set gas price
-	gasPrice, err := gas.GetPrice(cmd, args)
-	cli.CheckErr(cmd, err)
-	cli.Conn.SetGasPrice(gasPrice)
-
-	// Set nonce
-	n, err := nonce.Get()
-	cli.CheckErr(cmd, err)
-	cli.Conn.SetNonce(n)
-
 	var transactor interface{}
+	ConnectWithKeyStore(cmd, args)
 	// Create session
 	addr, err := cli.FlagOrConfigAddress(cmd, "address", contractConfigKey)
 	if err == nil {

--- a/commands/custodian/custodian.go
+++ b/commands/custodian/custodian.go
@@ -23,13 +23,13 @@ var (
 		Short:   "Deploys a new custodian registry contract",
 		Example: "t0ken custodian deploy --keystoreAddress owner",
 		Args:    cobra.NoArgs,
-		PreRun:  connectTransactor,
+		PreRun:  commands.ConnectWithKeyStore,
 		Run: func(cmd *cobra.Command, args []string) {
 			// Deploy the custodian using for the symbol/name/decimals
 			addr, tx, _, err := registry.DeployCustodian(cli.Conn.Opts, cli.Conn.Client)
 			cli.CheckErr(cmd, err)
 			cmd.Println("   Contract:", addr.String())
-			cli.PrintTransFn(cmd)(tx, nil)
+			cli.PrintTransactionFn(cmd)(tx, nil)
 		},
 	}
 

--- a/commands/custodian/setters.go
+++ b/commands/custodian/setters.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/tzero-dev/go-t0ken/cli"
 	"github.com/tzero-dev/go-t0ken/commands/destroyable"
+	"github.com/tzero-dev/go-t0ken/commands/gas"
 	"github.com/tzero-dev/go-t0ken/commands/lockable"
+	"github.com/tzero-dev/go-t0ken/commands/nonce"
 	"github.com/tzero-dev/go-t0ken/commands/ownable"
 )
 
@@ -19,7 +21,7 @@ var SetterCommands = []*cobra.Command{
 		PreRun:  connectTransactor,
 		Run: func(cmd *cobra.Command, args []string) {
 			custodian := common.HexToAddress(args[0])
-			cli.PrintTransFn(cmd)(transSession.Add(custodian))
+			cli.PrintTransactionFn(cmd)(transSession.Add(custodian))
 		},
 	},
 	&cobra.Command{
@@ -30,7 +32,7 @@ var SetterCommands = []*cobra.Command{
 		PreRun:  connectTransactor,
 		Run: func(cmd *cobra.Command, args []string) {
 			addr := common.HexToAddress(args[0])
-			cli.PrintTransFn(cmd)(transSession.Remove(addr))
+			cli.PrintTransactionFn(cmd)(transSession.Remove(addr))
 		},
 	},
 	&cobra.Command{
@@ -41,7 +43,7 @@ var SetterCommands = []*cobra.Command{
 		PreRun:  connectTransactor,
 		Run: func(cmd *cobra.Command, args []string) {
 			addr := common.HexToAddress(args[0])
-			cli.PrintTransFn(cmd)(transSession.SetStorage(addr))
+			cli.PrintTransactionFn(cmd)(transSession.SetStorage(addr))
 		},
 	},
 }
@@ -53,6 +55,10 @@ func init() {
 	SetterCommands = append(SetterCommands, ownable.NewSetterCommands(contractKey)...)
 
 	for _, cmd := range SetterCommands {
+		// Allow 'gasPrice' and 'nonce' flags
+		gas.Flag(cmd)
+		nonce.Flag(cmd)
+
 		// Allow providing contract 'address' flag
 		cmd.Flags().String("address", "", `address of the BrokerDealer registry contract (default "[`+contractKey+`] value from config")`)
 		cmd.Flags().Int("wait", -1, "waits the provided number of seconds for the transaction to be mined ('0' waits indefinitely)")

--- a/commands/destroyable/destroyable.go
+++ b/commands/destroyable/destroyable.go
@@ -29,7 +29,7 @@ func NewSetterCommands(contractConfigKey string) []*cobra.Command {
 			Args:   cobra.NoArgs,
 			PreRun: connect,
 			Run: func(cmd *cobra.Command, args []string) {
-				cli.PrintTransFn(cmd)(session.Kill())
+				cli.PrintTransactionFn(cmd)(session.Kill())
 			},
 		},
 	}

--- a/commands/ether/ether.go
+++ b/commands/ether/ether.go
@@ -48,7 +48,14 @@ var BalanceCommand = &cobra.Command{
 	PreRun: cli.Connect,
 	Args:   cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		addr, err := cli.GetArgAddress(0, args)
+		var addr common.Address
+		var err error
+
+		if common.IsHexAddress(args[0]) {
+			addr, err = cli.GetArgAddress(0, args)
+		} else {
+			addr, _, _, err = cli.AddressForKeystoreAlias(args[0])
+		}
 		cli.CheckErr(cmd, err)
 
 		balance, err := cli.Conn.BalanceAt(context.Background(), addr, nil)

--- a/commands/ether/ether.go
+++ b/commands/ether/ether.go
@@ -38,7 +38,7 @@ var SendCommand = &cobra.Command{
 		cli.CheckErr(cmd, err)
 
 		err = cli.Conn.SendTransaction(context.Background(), signedTx)
-		cli.PrintTransFn(cmd)(signedTx, err)
+		cli.PrintTransactionFn(cmd)(signedTx, err)
 	},
 }
 

--- a/commands/gas/gas.go
+++ b/commands/gas/gas.go
@@ -33,7 +33,7 @@ var PriceCommand = &cobra.Command{
 // GasPrice returns the gas price flag value, or the suggested gas price when unset.
 func GetPrice(cmd *cobra.Command, args []string) (*big.Int, error) {
 	f := cmd.Flag("gasPrice")
-	if f == nil {
+	if f == nil || gasPrice == 0 {
 		return cli.Conn.SuggestGasPrice(context.Background())
 	}
 	g := big.NewFloat(gasPrice)

--- a/commands/gas/gas.go
+++ b/commands/gas/gas.go
@@ -30,7 +30,7 @@ var PriceCommand = &cobra.Command{
 	},
 }
 
-// GasPrice Returns the gas price flag value, or the suggested gas price when unset.
+// GasPrice returns the gas price flag value, or the suggested gas price when unset.
 func GetPrice(cmd *cobra.Command, args []string) (*big.Int, error) {
 	f := cmd.Flag("gasPrice")
 	if f == nil {
@@ -40,6 +40,19 @@ func GetPrice(cmd *cobra.Command, args []string) (*big.Int, error) {
 	wei := new(big.Int)
 	units.ConvertFloat(g, units.Gwei, units.Wei).Int(wei)
 	return wei, nil
+}
+
+// GetFlagValue returns the flag value converted from Gwei to Wei.
+func GetFlagValue(cmd *cobra.Command) *big.Int {
+	f := cmd.Flag("gasPrice")
+	if f == nil || gasPrice == 0 {
+		return nil
+	}
+
+	g := big.NewFloat(gasPrice)
+	wei := new(big.Int)
+	units.ConvertFloat(g, units.Gwei, units.Wei).Int(wei)
+	return wei
 }
 
 // Flag adds the 'gasPrice' flag to the given command.

--- a/commands/investor/investor.go
+++ b/commands/investor/investor.go
@@ -23,13 +23,13 @@ var (
 		Short:   "Deploys a new investor contract",
 		Example: "t0ken investor deploy --keystoreAddress owner",
 		Args:    cobra.NoArgs,
-		PreRun:  connectTransactor,
+		PreRun:  commands.ConnectWithKeyStore,
 		Run: func(cmd *cobra.Command, args []string) {
 			// Deploy the investor registry using for the symbol/name/decimals
 			addr, tx, _, err := registry.DeployInvestor(cli.Conn.Opts, cli.Conn.Client)
 			cli.CheckErr(cmd, err)
 			cmd.Println("   Contract:", addr.String())
-			cli.PrintTransFn(cmd)(tx, nil)
+			cli.PrintTransactionFn(cmd)(tx, nil)
 		},
 	}
 

--- a/commands/investor/setters.go
+++ b/commands/investor/setters.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/tzero-dev/go-t0ken/cli"
 	"github.com/tzero-dev/go-t0ken/commands/destroyable"
+	"github.com/tzero-dev/go-t0ken/commands/gas"
 	"github.com/tzero-dev/go-t0ken/commands/lockable"
+	"github.com/tzero-dev/go-t0ken/commands/nonce"
 	"github.com/tzero-dev/go-t0ken/commands/ownable"
 )
 
@@ -35,7 +37,7 @@ var SetterCommands = []*cobra.Command{
 			var hash [32]byte
 			copy(hash[:], h)
 
-			cli.PrintTransFn(cmd)(transSession.Add(investor, hash, country, big.NewInt(accreditation.Unix())))
+			cli.PrintTransactionFn(cmd)(transSession.Add(investor, hash, country, big.NewInt(accreditation.Unix())))
 		},
 	},
 	&cobra.Command{
@@ -46,7 +48,7 @@ var SetterCommands = []*cobra.Command{
 		PreRun:  connectTransactor,
 		Run: func(cmd *cobra.Command, args []string) {
 			investor := common.HexToAddress(args[0])
-			cli.PrintTransFn(cmd)(transSession.Remove(investor))
+			cli.PrintTransactionFn(cmd)(transSession.Remove(investor))
 		},
 	},
 	&cobra.Command{
@@ -58,7 +60,7 @@ var SetterCommands = []*cobra.Command{
 		Run: func(cmd *cobra.Command, args []string) {
 			investor := common.HexToAddress(args[0])
 			accreditation, _ := cli.DateFromArg(args[2])
-			cli.PrintTransFn(cmd)(transSession.SetAccreditation(investor, big.NewInt(accreditation.Unix())))
+			cli.PrintTransactionFn(cmd)(transSession.SetAccreditation(investor, big.NewInt(accreditation.Unix())))
 		},
 	},
 	&cobra.Command{
@@ -70,7 +72,7 @@ var SetterCommands = []*cobra.Command{
 		Run: func(cmd *cobra.Command, args []string) {
 			investor := common.HexToAddress(args[0])
 			country, _ := cli.CountryFromArg(args[2])
-			cli.PrintTransFn(cmd)(transSession.SetCountry(investor, country))
+			cli.PrintTransactionFn(cmd)(transSession.SetCountry(investor, country))
 		},
 	},
 	&cobra.Command{
@@ -82,7 +84,7 @@ var SetterCommands = []*cobra.Command{
 		Run: func(cmd *cobra.Command, args []string) {
 			investor := common.HexToAddress(args[0])
 			frozen, _ := strconv.ParseBool(args[1])
-			cli.PrintTransFn(cmd)(transSession.SetFrozen(investor, frozen))
+			cli.PrintTransactionFn(cmd)(transSession.SetFrozen(investor, frozen))
 		},
 	},
 	&cobra.Command{
@@ -99,7 +101,7 @@ var SetterCommands = []*cobra.Command{
 			var hash [32]byte
 			copy(hash[:], h)
 
-			cli.PrintTransFn(cmd)(transSession.SetHash(investor, hash))
+			cli.PrintTransactionFn(cmd)(transSession.SetHash(investor, hash))
 		},
 	},
 	&cobra.Command{
@@ -110,7 +112,7 @@ var SetterCommands = []*cobra.Command{
 		PreRun:  connectTransactor,
 		Run: func(cmd *cobra.Command, args []string) {
 			addr := common.HexToAddress(args[0])
-			cli.PrintTransFn(cmd)(transSession.SetStorage(addr))
+			cli.PrintTransactionFn(cmd)(transSession.SetStorage(addr))
 		},
 	},
 }
@@ -122,6 +124,10 @@ func init() {
 	SetterCommands = append(SetterCommands, ownable.NewSetterCommands(contractKey)...)
 
 	for _, cmd := range SetterCommands {
+		// Allow 'gasPrice' and 'nonce' flags
+		gas.Flag(cmd)
+		nonce.Flag(cmd)
+
 		// Allow providing contract 'address' flag
 		cmd.Flags().String("address", "", `address of the BrokerDealer registry contract (default "[`+contractKey+`] value from config")`)
 		cmd.Flags().Int("wait", -1, "waits the provided number of seconds for the transaction to be mined ('0' waits indefinitely)")

--- a/commands/investor/setters.go
+++ b/commands/investor/setters.go
@@ -25,7 +25,7 @@ var SetterCommands = []*cobra.Command{
 	0xa1896382c22b03c562b0241324cfca19505cc5c78eb06751d9cee690e21ed6a1 \
 	US \
 	2020-07-11 --keystoreAddress broker`,
-		Args:   cli.ChainArgs(cli.AddressArgFunc("investor", 0), cli.HexArgFunc("hash", 1, 32), cli.CountryCodeArgFunc("country", 2), cli.DateArgFunc("accreditation", 3)),
+		Args:   cli.ChainArgs(cli.AddressArgFunc("investor", 0), cli.HexArgFunc("hash", 1, 16), cli.CountryCodeArgFunc("country", 2), cli.DateArgFunc("accreditation", 3)),
 		PreRun: connectTransactor,
 		Run: func(cmd *cobra.Command, args []string) {
 			investor := common.HexToAddress(args[0])

--- a/commands/lockable/lockable.go
+++ b/commands/lockable/lockable.go
@@ -57,7 +57,7 @@ func NewSetterCommands(contractConfigKey string) []*cobra.Command {
 			PreRun: connect,
 			Run: func(cmd *cobra.Command, args []string) {
 				locked, _ := strconv.ParseBool(args[0])
-				cli.PrintTransFn(cmd)(session.SetLocked(locked))
+				cli.PrintTransactionFn(cmd)(session.SetLocked(locked))
 			},
 		},
 	}

--- a/commands/nonce/nonce.go
+++ b/commands/nonce/nonce.go
@@ -3,6 +3,7 @@ package nonce
 import (
 	"context"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/spf13/cobra"
 
 	"github.com/tzero-dev/go-t0ken/cli"
@@ -18,10 +19,17 @@ var Command = &cobra.Command{
 var NextCommand = &cobra.Command{
 	Use:    "next <address>",
 	Short:  "gets the next nonce for an address",
-	Args:   cobra.MaximumNArgs(1),
+	Args:   cobra.ExactArgs(1),
 	PreRun: cli.Connect,
 	Run: func(cmd *cobra.Command, args []string) {
-		addr, err := cli.GetArgAddress(0, args)
+		var addr common.Address
+		var err error
+
+		if common.IsHexAddress(args[0]) {
+			addr, err = cli.GetArgAddress(0, args)
+		} else {
+			addr, _, _, err = cli.AddressForKeystoreAlias(args[0])
+		}
 		cli.CheckErr(cmd, err)
 
 		n, err := cli.Conn.PendingNonceAt(context.Background(), addr)

--- a/commands/ownable/ownable.go
+++ b/commands/ownable/ownable.go
@@ -55,7 +55,7 @@ func NewSetterCommands(contractConfigKey string) []*cobra.Command {
 			PreRun: connect,
 			Run: func(cmd *cobra.Command, args []string) {
 				addr := common.HexToAddress(args[0])
-				cli.PrintTransFn(cmd)(session.TransferOwner(addr))
+				cli.PrintTransactionFn(cmd)(session.TransferOwner(addr))
 			},
 		},
 	}

--- a/commands/storage/storage.go
+++ b/commands/storage/storage.go
@@ -23,13 +23,13 @@ var (
 		Short:   "Deploys a new storage contract",
 		Example: "t0ken storage deploy --keystoreAddress owner",
 		Args:    cobra.NoArgs,
-		PreRun:  connectTransactor,
+		PreRun:  commands.ConnectWithKeyStore,
 		Run: func(cmd *cobra.Command, args []string) {
 			// Deploy the storage using for the symbol/name/decimals
 			addr, tx, _, err := registry.DeployStorage(cli.Conn.Opts, cli.Conn.Client)
 			cli.CheckErr(cmd, err)
 			cmd.Println("   Contract:", addr.String())
-			cli.PrintTransFn(cmd)(tx, nil)
+			cli.PrintTransactionFn(cmd)(tx, nil)
 		},
 	}
 

--- a/commands/storage/storage.go
+++ b/commands/storage/storage.go
@@ -1,6 +1,11 @@
 package storage
 
 import (
+	"context"
+	"fmt"
+	"math/big"
+	"strconv"
+
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/spf13/cobra"
@@ -30,6 +35,43 @@ var (
 			cli.CheckErr(cmd, err)
 			cmd.Println("   Contract:", addr.String())
 			cli.PrintTransactionFn(cmd)(tx, nil)
+		},
+	}
+
+	AuditCommand = &cobra.Command{
+		Use:    "audit <kind>",
+		Short:  "Audit the accounts of <kind>, outputting CSV to <stdout>",
+		Args:   cli.IntArgFunc("kind", 0),
+		PreRun: connectCaller,
+		Run: func(cmd *cobra.Command, args []string) {
+			var kind uint8
+			if cli.IsIntArg("kind", args, 0) == nil {
+				k, _ := strconv.Atoi(args[0])
+				kind = uint8(k)
+			}
+
+			// Get the current block
+			header, err := cli.Conn.HeaderByNumber(context.Background(), nil)
+			cli.CheckErr(cmd, err)
+
+			// Pin the requests to the same block (avoid any state changes during audit)
+			callSession.CallOpts.BlockNumber = header.Number
+			n, err := callSession.Accounts()
+			cli.CheckErr(cmd, err)
+
+			one := big.NewInt(1)
+			index := big.NewInt(0)
+			cmd.Printf("Block: %s\n", header.Number.String())
+			fmt.Println("address,kind,frozen,parent")
+			for i := int64(0); i < n.Int64(); i++ {
+				addr, k, frozen, parent, err := callSession.AccountAt(index)
+				cli.CheckErr(cmd, err)
+
+				if kind == 0 || k == kind {
+					fmt.Printf("%s,%d,%t,%s\n", addr.String(), k, frozen, parent.String())
+				}
+				index.Add(index, one)
+			}
 		},
 	}
 

--- a/commands/token/setters.go
+++ b/commands/token/setters.go
@@ -25,7 +25,7 @@ var SetterCommands = []*cobra.Command{
 		Run: func(cmd *cobra.Command, args []string) {
 			addr := common.HexToAddress(args[0])
 			quantity, _ := new(big.Int).SetString(args[1], 10)
-			cli.PrintTransFn(cmd)(transSession.Approve(addr, quantity))
+			cli.PrintTransactionFn(cmd)(transSession.Approve(addr, quantity))
 		},
 	},
 	&cobra.Command{
@@ -37,7 +37,7 @@ var SetterCommands = []*cobra.Command{
 		Run: func(cmd *cobra.Command, args []string) {
 			addr := common.HexToAddress(args[0])
 			replacement := common.HexToAddress(args[1])
-			cli.PrintTransFn(cmd)(transSession.CancelAndReissue(addr, replacement))
+			cli.PrintTransactionFn(cmd)(transSession.CancelAndReissue(addr, replacement))
 		},
 	},
 	&cobra.Command{
@@ -47,7 +47,7 @@ var SetterCommands = []*cobra.Command{
 		Args:    cobra.NoArgs,
 		PreRun:  connectTransactor,
 		Run: func(cmd *cobra.Command, args []string) {
-			cli.PrintTransFn(cmd)(transSession.FinishIssuing())
+			cli.PrintTransactionFn(cmd)(transSession.FinishIssuing())
 		},
 	},
 	&cobra.Command{
@@ -58,7 +58,7 @@ var SetterCommands = []*cobra.Command{
 		PreRun:  connectTransactor,
 		Run: func(cmd *cobra.Command, args []string) {
 			quantity, _ := new(big.Int).SetString(args[0], 10)
-			cli.PrintTransFn(cmd)(transSession.IssueTokens(quantity))
+			cli.PrintTransactionFn(cmd)(transSession.IssueTokens(quantity))
 		},
 	},
 	&cobra.Command{
@@ -69,7 +69,7 @@ var SetterCommands = []*cobra.Command{
 		PreRun:  connectTransactor,
 		Run: func(cmd *cobra.Command, args []string) {
 			addr := common.HexToAddress(args[0])
-			cli.PrintTransFn(cmd)(transSession.SetCompliance(addr))
+			cli.PrintTransactionFn(cmd)(transSession.SetCompliance(addr))
 		},
 	},
 	&cobra.Command{
@@ -80,7 +80,7 @@ var SetterCommands = []*cobra.Command{
 		PreRun:  connectTransactor,
 		Run: func(cmd *cobra.Command, args []string) {
 			addr := common.HexToAddress(args[0])
-			cli.PrintTransFn(cmd)(transSession.SetIssuer(addr))
+			cli.PrintTransactionFn(cmd)(transSession.SetIssuer(addr))
 		},
 	},
 	&cobra.Command{
@@ -92,7 +92,7 @@ var SetterCommands = []*cobra.Command{
 		Run: func(cmd *cobra.Command, args []string) {
 			addr := common.HexToAddress(args[0])
 			qty, _ := new(big.Int).SetString(args[1], 10)
-			cli.PrintTransFn(cmd)(transSession.Transfer(addr, qty))
+			cli.PrintTransactionFn(cmd)(transSession.Transfer(addr, qty))
 		},
 	},
 	&cobra.Command{
@@ -105,7 +105,7 @@ var SetterCommands = []*cobra.Command{
 			sender := common.HexToAddress(args[0])
 			recipient := common.HexToAddress(args[1])
 			qty, _ := new(big.Int).SetString(args[2], 10)
-			cli.PrintTransFn(cmd)(transSession.TransferFrom(sender, recipient, qty))
+			cli.PrintTransactionFn(cmd)(transSession.TransferFrom(sender, recipient, qty))
 		},
 	},
 	&cobra.Command{
@@ -118,7 +118,7 @@ var SetterCommands = []*cobra.Command{
 			sender := common.HexToAddress(args[0])
 			recipient := common.HexToAddress(args[1])
 			qty, _ := new(big.Int).SetString(args[2], 10)
-			cli.PrintTransFn(cmd)(transSession.TransferOverride(sender, recipient, qty))
+			cli.PrintTransactionFn(cmd)(transSession.TransferOverride(sender, recipient, qty))
 		},
 	},
 }

--- a/commands/token/token.go
+++ b/commands/token/token.go
@@ -25,7 +25,7 @@ var (
 		Short:   "Deploys a new t0ken contract",
 		Example: "t0ken token deploy --keystoreAddress owner",
 		Args:    cli.ChainArgs(cobra.ExactArgs(3), cli.UintArgFunc("decimals", 2, 8)),
-		PreRun:  connectTransactor,
+		PreRun:  commands.ConnectWithKeyStore,
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get the token data args
 			name := args[0]
@@ -36,7 +36,7 @@ var (
 			addr, tx, _, err := erc20.DeployT0ken(cli.Conn.Opts, cli.Conn.Client, name, symbol, uint8(decimals))
 			cli.CheckErr(cmd, err)
 			cmd.Println("   Contract:", addr.String())
-			cli.PrintTransFn(cmd)(tx, nil)
+			cli.PrintTransactionFn(cmd)(tx, nil)
 		},
 	}
 

--- a/commands/transaction/transaction.go
+++ b/commands/transaction/transaction.go
@@ -1,0 +1,139 @@
+package transaction
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/spf13/cobra"
+
+	"github.com/tzero-dev/go-t0ken/cli"
+	"github.com/tzero-dev/go-t0ken/commands/gas"
+	"github.com/tzero-dev/go-t0ken/commands/nonce"
+	"github.com/tzero-dev/go-t0ken/units"
+)
+
+var Command = &cobra.Command{
+	Use:   "transaction",
+	Short: "Transaction utilities",
+}
+
+var ReplayCommand = &cobra.Command{
+	Use:    "replay <transaction>...",
+	Short:  "Replays the pending <transaction>... by doubling the gas price (can override this with the 'gasPrice' flag)",
+	PreRun: cli.ConnectWithKeyStore,
+	Run: func(cmd *cobra.Command, args []string) {
+		hashes, err := getHashes(args)
+		cli.CheckErr(cmd, err)
+		for i := range hashes {
+			// Get the transaction and new gas-price
+			tx, gasPrice, err := transAndGas(cmd, hashes[i])
+			cli.CheckErr(cmd, err)
+
+			// Get the latest block, for gasLimit
+			b, err := cli.Conn.BlockByNumber(context.Background(), nil)
+			cli.CheckErr(cmd, err)
+
+			// Create the replay transaction or contract creation
+			if tx.To() != nil {
+				tx = types.NewTransaction(tx.Nonce(), *tx.To(), tx.Value(), b.GasLimit(), gasPrice, tx.Data())
+			} else {
+				// NOTE: Replaying contract creation transactions doesn't currently work, as Geth always returns the error: 'known transaction: <tx>'.
+				//       To work around this, cancel the transaction first, then resubmit the contract creation.
+				types.NewContractCreation(tx.Nonce(), tx.Value(), b.GasLimit(), gasPrice, tx.Data())
+			}
+
+			// Sign & replay the transaction with the new gas-price
+			signedTx, err := cli.Conn.Opts.Signer(types.HomesteadSigner{}, cli.Conn.Opts.From, tx)
+			if err == nil {
+				err = cli.Conn.SendTransaction(context.Background(), signedTx)
+			}
+			cli.CheckErr(cmd, err)
+			cli.PrintTransactionFn(cmd)(signedTx, err)
+		}
+	},
+}
+
+var CancelCommand = &cobra.Command{
+	Use:    "cancel <transaction>...",
+	Short:  "Cancels the pending <transaction>...",
+	PreRun: cli.ConnectWithKeyStore,
+	Run: func(cmd *cobra.Command, args []string) {
+		hashes, err := getHashes(args)
+		cli.CheckErr(cmd, err)
+		for i := range hashes {
+			// Get the transaction and new gas-price
+			tx, gasPrice, err := transAndGas(cmd, hashes[i])
+			cli.CheckErr(cmd, err)
+
+			// Send 0 eth with the new gas value to try an cancel the pending transaction with matching nonce.
+			to := cli.Conn.Opts.From
+			tx = types.NewTransaction(tx.Nonce(), to, big.NewInt(0), uint64(21000), gasPrice, nil)
+			signedTx, err := cli.Conn.Opts.Signer(types.HomesteadSigner{}, cli.Conn.Opts.From, tx)
+			cli.CheckErr(cmd, err)
+			err = cli.Conn.SendTransaction(context.Background(), signedTx)
+			cli.PrintTransactionFn(cmd)(signedTx, err)
+		}
+	},
+}
+
+var NextAddressCommand = &cobra.Command{
+	Use:    "nextAddress [flags]",
+	Short:  "Outputs the next contract address, supply the 'nonce' flag whenyou want a future address",
+	PreRun: cli.ConnectWithKeyStore,
+	Run: func(cmd *cobra.Command, args []string) {
+		n, err := nonce.Get()
+		cli.CheckErr(cmd, err)
+		addr := crypto.CreateAddress(cli.Conn.Opts.From, n)
+		cmd.Println(addr.String())
+	},
+}
+
+func getHashes(args []string) ([]common.Hash, error) {
+	hashes := make([]common.Hash, len(args), len(args))
+	for i := range args {
+		h := common.HexToHash(args[i])
+		if len(h.Bytes()) != 32 {
+			return hashes, fmt.Errorf("invalid hash length of %d", len(h))
+		}
+		hashes[i] = h
+	}
+	return hashes, nil
+}
+
+func transAndGas(cmd *cobra.Command, h common.Hash) (*types.Transaction, *big.Int, error) {
+	// Get the transaction for the hash, ensuring it's valid and not in a pending state
+	tx, pending, err := cli.Conn.TransactionByHash(context.Background(), h)
+	if err != nil {
+		return tx, nil, err
+	} else if !pending {
+		return tx, nil, errors.New("transaction must be in 'pending' state")
+	}
+
+	// Get gas price (use the value from 'gasPrice' flag or add 50% to the existing transaction value)
+	gasPrice := gas.GetFlagValue(cmd)
+	if gasPrice == nil {
+		// Get the original transaction's gas price
+		gasPrice = tx.GasPrice()
+
+		// Convert from Wei to Gwei and add 20% (must increase by more than 10% for the replacement to be accepted)
+		g := units.ConvertInt(gasPrice, units.Wei, units.Gwei)
+		g.Mul(g, big.NewFloat(1.2))
+
+		// Convert Gwei + 20% back to Wei
+		units.ConvertFloat(g, units.Gwei, units.Wei).Int(gasPrice)
+	}
+
+	return tx, gasPrice, nil
+}
+
+func init() {
+	gas.Flag(ReplayCommand)
+	gas.Flag(CancelCommand)
+
+	nonce.Flag(NextAddressCommand)
+}

--- a/connection/connection.go
+++ b/connection/connection.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
 )
 
 var (
@@ -24,8 +25,9 @@ var (
 // Connection wraps 'etherclient.Client' to hold transactor options and a key-store.
 type Connection struct {
 	*ethclient.Client
-	Opts     *bind.TransactOpts
-	KeyStore *keystore.KeyStore
+	rpcClient *rpc.Client
+	Opts      *bind.TransactOpts
+	KeyStore  *keystore.KeyStore
 }
 
 // accountFor returns the matching account within the key-store.
@@ -109,13 +111,26 @@ func (c *Connection) SetTransactorFromKeyStore(a common.Address, password string
 	return c.SetTransactor(key.URL.Path, password)
 }
 
+// RawCall performs a JSON-RPC call against the underlying RPC connection
+func (c *Connection) RawCall(result interface{}, method string, args ...interface{}) error {
+	return c.rpcClient.CallContext(context.Background(), result, method, args...)
+}
+
+// RawCall performs a JSON-RPC call against the underlying RPC connection, using the given context
+func (c *Connection) RawCallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error {
+	return c.rpcClient.CallContext(ctx, result, method, args...)
+}
+
 // New creates a new connection
 func New(url string) (*Connection, error) {
-	c, err := ethclient.Dial(url)
+	//client, err := ethclient.Dial(url)
+	rpcClient, err := rpc.Dial(url)
 	if err != nil {
 		return nil, err
 	}
-	return &Connection{c, nil, nil}, err
+	client := ethclient.NewClient(rpcClient)
+	//return &Connection{client, nil, nil}, err
+	return &Connection{client, rpcClient, nil, nil}, err
 }
 
 // NewForKey creates a new connection using the given key-store file and password.

--- a/connection/connection.go
+++ b/connection/connection.go
@@ -49,6 +49,7 @@ func NewTransactor(keyFile string, password string) (*bind.TransactOpts, error) 
 	key := strings.NewReader(string(b))
 	auth, err := bind.NewTransactor(key, password)
 	return auth, err
+	//bind.WaitMined(
 }
 
 // SetNextNonce sets the next nonce of the transactor address.
@@ -123,13 +124,11 @@ func (c *Connection) RawCallContext(ctx context.Context, result interface{}, met
 
 // New creates a new connection
 func New(url string) (*Connection, error) {
-	//client, err := ethclient.Dial(url)
 	rpcClient, err := rpc.Dial(url)
 	if err != nil {
 		return nil, err
 	}
 	client := ethclient.NewClient(rpcClient)
-	//return &Connection{client, nil, nil}, err
 	return &Connection{client, rpcClient, nil, nil}, err
 }
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/aristanetworks/goarista v0.0.0-20190204200901-2166578f3448 // indirect
 	github.com/btcsuite/btcd v0.0.0-20190115013929-ed77733ec07d // indirect
 	github.com/deckarep/golang-set v1.7.1 // indirect
-	github.com/ethereum/go-ethereum v1.8.22
+	github.com/ethereum/go-ethereum v1.8.23
 	github.com/fatih/color v1.7.0 // indirect
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/deckarep/golang-set v1.7.1 h1:SCQV0S6gTtp6itiFrTqI+pfmJ4LN85S1YzhDf9rTHJQ=
 github.com/deckarep/golang-set v1.7.1/go.mod h1:93vsz/8Wt4joVM7c2AVqh+YRMiUSc14yDtF28KmMOgQ=
-github.com/ethereum/go-ethereum v1.8.22 h1:y8RPBpBOF0/Gm8tV4Ut0WMa6RvY0e4XFIT6zASAOT0I=
-github.com/ethereum/go-ethereum v1.8.22/go.mod h1:PwpWDrCLZrV+tfrhqqF6kPknbISMHaJv9Ln3kPCZLwY=
+github.com/ethereum/go-ethereum v1.8.23 h1:xVKYpRpe3cbkaWN8gsRgStsyTvz3s82PcQsbEofjhEQ=
+github.com/ethereum/go-ethereum v1.8.23/go.mod h1:PwpWDrCLZrV+tfrhqqF6kPknbISMHaJv9Ln3kPCZLwY=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=

--- a/t0ken.go
+++ b/t0ken.go
@@ -1,0 +1,3 @@
+package t0ken
+
+const VERSION = "0.0.3"

--- a/xgo.sh
+++ b/xgo.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+xgo \
+	-v \
+	--targets="darwin/amd64,linux/amd64,windows/amd64" \
+	--dest=dist \
+	github.com/tzero-dev/go-t0ken/cmd/t0ken


### PR DESCRIPTION
 - Allows you to wait for a transaction to be accepted into a block, and print the resulting transaction/block information.
 - Allows passing in either an address of address alias, from `t0ken.yaml`, into the address arg of `nonce` and `ether` commands
 - Allows setting a password in the `t0ken.yaml` for an address alias _(you shouldn't ever do this though)_
 - Creates a raw RPC connection object so we can perform raw queries _(we need this to get the block number of a transaction receipt, since it's not available in native geth libs)_
 - Resolves issue with hex arg length checking
 - Adds `t0kenbatch` command for batching issuance and investor onboarding from CSV files